### PR TITLE
Add interactive normative model builder

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,11 +6,12 @@ st.set_page_config(page_title="PM4Py TBR — Multipáginas", layout="wide")
 st.title("Conformance via Token-Based Replay (PM4Py)")
 st.markdown(
     """
-Este app possui três páginas no menu à esquerda:
+Este app possui quatro páginas no menu à esquerda:
 
-1. **Modelo Normativo** — visualização do fluxo normativo (alto nível).
-2. **Token Replay** — execução do TBR com controles manuais, contendo **o modelo normativo no topo** e **o replay abaixo**, **empilhados verticalmente** (não lado a lado), para facilitar a inspeção em modelos grandes.
-3. **Gerador de Logs XES/CSV** — criação de logs sintéticos a partir de frequências de traços, com opção de download em XES ou CSV.
+1. **Gerador de Modelo Normativo** — crie um fluxo normativo interativo e exporte o resultado.
+2. **Modelo Normativo** — visualização do fluxo normativo (alto nível).
+3. **Token Replay** — execução do TBR com controles manuais, contendo **o modelo normativo no topo** e **o replay abaixo**, **empilhados verticalmente** (não lado a lado), para facilitar a inspeção em modelos grandes.
+4. **Gerador de Logs XES/CSV** — criação de logs sintéticos a partir de frequências de traços, com opção de download em XES ou CSV.
 
 """
 )

--- a/pages/0_Gerador_Modelo_Normativo.py
+++ b/pages/0_Gerador_Modelo_Normativo.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+"""Página para edição e exportação de modelos normativos."""
+
+import json
+import streamlit as st
+from streamlit_flow.elements import StreamlitFlowNode, StreamlitFlowEdge
+
+from replayviz import ensure_flow_state_slot, update_flow_state_slot, render_flow_slot
+
+st.set_page_config(page_title="Gerador de Modelo Normativo", layout="wide")
+st.title("Gerador de Modelo Normativo")
+
+# Espaço de sessão onde o fluxo será guardado
+STATE_SLOT = "norm_model_builder"
+ensure_flow_state_slot(STATE_SLOT)
+
+# Modelo padrão: sequência a → c → d → e → h
+default_sequence = ["a", "c", "d", "e", "h"]
+fs = st.session_state[STATE_SLOT]
+try:
+    has_nodes = bool(fs.nodes)  # type: ignore[attr-defined]
+except AttributeError:
+    has_nodes = bool(fs["nodes"])
+
+if not has_nodes:
+    nodes = []
+    edges = []
+    y = 80
+    spacing = 120
+    for i, label in enumerate(default_sequence):
+        nodes.append(
+            StreamlitFlowNode(
+                id=label,
+                pos=(i * spacing, y),
+                data={"content": f"<div><b>{label}</b></div>"},
+                node_type="default",
+                source_position="right",
+                target_position="left",
+            )
+        )
+
+    for src, dst in zip(default_sequence[:-1], default_sequence[1:]):
+        edges.append(
+            StreamlitFlowEdge(
+                id=f"e_{src}_{dst}", source=src, target=dst, label=""
+            )
+        )
+
+    update_flow_state_slot(STATE_SLOT, nodes, edges)
+
+# Renderiza o editor de fluxo
+render_flow_slot(STATE_SLOT, key="norm_builder", height=400, fit_view=True)
+
+# Exporta para JSON
+fs = st.session_state[STATE_SLOT]
+try:
+    nodes = fs.nodes; edges = fs.edges  # type: ignore[attr-defined]
+except AttributeError:
+    nodes = fs["nodes"]; edges = fs["edges"]
+
+export_data = {
+    "nodes": [n.__dict__ for n in nodes],
+    "edges": [e.__dict__ for e in edges],
+}
+
+st.download_button(
+    "Exportar modelo",
+    data=json.dumps(export_data, ensure_ascii=False, indent=2),
+    file_name="modelo_normativo.json",
+    mime="application/json",
+)
+
+st.caption(
+    "Altere o fluxo acima e use **Exportar modelo** para salvar o modelo em JSON."
+)
+


### PR DESCRIPTION
## Summary
- introduce "Gerador de Modelo Normativo" page to build and export models with Streamlit Flow
- list the new page on the main index

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab7e67daa483318daed322aa6f97cc