### PR TITLE
feat: update token replay flow per trace

### DIFF
--- a/pages/2_Token_Replay.py
+++ b/pages/2_Token_Replay.py
@@ -11,11 +11,11 @@ from replayviz import (
     markings_along_trace, markings_equal, format_marking,
     ensure_flow_state_slot, update_flow_state_slot, render_flow_slot,
 )
-from replayviz.flowviz import build_normative_flow_N3, build_nodes_edges_for_marking_N3
+from replayviz.flowviz import build_nodes_edges_for_marking_N3, build_trace_flow
 from replayviz.utils_xes import read_xes_any  # <- leitor robusto (path/bytes)
 
 st.set_page_config(page_title="Token Replay — N₃", layout="wide")
-st.title("Token-Based Replay (N₃) — normativo acima, Petri com fichas abaixo")
+st.title("Token-Based Replay (N₃) — fluxo do traço acima, Petri com fichas abaixo")
 
 # -----------------------------
 # Leitura de log (robusta)
@@ -86,13 +86,13 @@ if st.session_state.last_params != curr_params:
 st.session_state.frame = max(0, min(st.session_state.frame, max_step))
 
 # -----------------------------
-# 1) Normativo N₃ (alto nível)
+# 1) Fluxo do traço (alto nível)
 # -----------------------------
-st.subheader("Modelo normativo (referência)")
-n_nodes, n_edges = build_normative_flow_N3()
-ensure_flow_state_slot("flow_norm_on_replay_page")
-update_flow_state_slot("flow_norm_on_replay_page", n_nodes, n_edges)
-render_flow_slot("flow_norm_on_replay_page", key="norm_replay_page", height=260, fit_view=True)
+st.subheader("Fluxo do traço selecionado")
+nodes_top, edges_top = build_trace_flow(log[trace_idx])
+ensure_flow_state_slot("flow_trace_overview")
+update_flow_state_slot("flow_trace_overview", nodes_top, edges_top)
+render_flow_slot("flow_trace_overview", key="trace_overview", height=260, fit_view=True)
 
 st.markdown("---")
 

--- a/replayviz/__init__.py
+++ b/replayviz/__init__.py
@@ -13,6 +13,7 @@ from .markings import (
 from .flowviz import (
     build_nodes_edges_for_marking_N3,
     build_normative_flow_N3,
+    build_trace_flow,
 )
 
 # Estado do componente streamlit-flow

--- a/replayviz/flowviz.py
+++ b/replayviz/flowviz.py
@@ -1,5 +1,6 @@
 from typing import Dict, List, Optional, Tuple
 from pm4py.objects.petri_net.obj import PetriNet, Marking
+from pm4py.objects.log.obj import Trace
 from streamlit_flow.elements import StreamlitFlowNode, StreamlitFlowEdge
 
 def _token_html(k: int, max_dots: int = 6) -> str:
@@ -188,3 +189,89 @@ def build_normative_flow_N3() -> Tuple[List[StreamlitFlowNode], List[StreamlitFl
     E("e","p5"); E("p5","h"); E("h","p_end")
 
     return nodes, edges
+
+
+# Traço sequencial simples (start -> eventos -> end)
+def build_trace_flow(trace: Trace) -> Tuple[List[StreamlitFlowNode], List[StreamlitFlowEdge]]:
+    nodes: List[StreamlitFlowNode] = []
+    edges: List[StreamlitFlowEdge] = []
+
+    circle_style = {
+        "border": "2px solid #6b7280",
+        "borderRadius": "9999px",
+        "width": 28,
+        "height": 28,
+        "background": "#fff",
+    }
+
+    y = 60
+    x = 0
+
+    # start
+    nodes.append(
+        StreamlitFlowNode(
+            id="start",
+            pos=(x, y),
+            data={"content": ""},
+            node_type="default",
+            source_position="right",
+            target_position="left",
+            style=circle_style,
+        )
+    )
+
+    prev_id = "start"
+
+    # eventos sequenciais
+    for i, ev in enumerate(trace, start=1):
+        x += 80
+        name = ev.get("concept:name", "?")
+        node_id = f"ev_{i}"
+        t_style = _trans_style(name, highlighted=False)
+        nodes.append(
+            StreamlitFlowNode(
+                id=node_id,
+                pos=(x, y),
+                data={"content": f"<div><b>{name}</b></div>"},
+                node_type="default",
+                source_position="right",
+                target_position="left",
+                style=t_style,
+            )
+        )
+        edges.append(
+            StreamlitFlowEdge(
+                id=f"e_{prev_id}_{node_id}",
+                source=prev_id,
+                target=node_id,
+                label="",
+                animated=False,
+            )
+        )
+        prev_id = node_id
+
+    # end
+    x += 80
+    nodes.append(
+        StreamlitFlowNode(
+            id="end",
+            pos=(x, y),
+            data={"content": ""},
+            node_type="default",
+            source_position="right",
+            target_position="left",
+            style=circle_style,
+        )
+    )
+    edges.append(
+        StreamlitFlowEdge(
+            id=f"e_{prev_id}_end",
+            source=prev_id,
+            target="end",
+            label="",
+            animated=False,
+        )
+    )
+
+    return nodes, edges
+


### PR DESCRIPTION
## Summary
- show trace-specific flow diagram in token replay page
- add helper to build flow graph from a trace

## Testing
- `python -m py_compile pages/2_Token_Replay.py replayviz/flowviz.py replayviz/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab8cab14188331831cf9f90b5b4755