### PR TITLE
Add PM4Py alignments page with CSV upload

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,12 +6,13 @@ st.set_page_config(page_title="PM4Py TBR — Multipáginas", layout="wide")
 st.title("Conformance via Token-Based Replay (PM4Py)")
 st.markdown(
     """
-Este app possui quatro páginas no menu à esquerda:
+Este app possui cinco páginas no menu à esquerda:
 
 1. **Gerador de Modelo Normativo** — crie um fluxo normativo interativo e exporte o resultado.
 2. **Modelo Normativo** — visualização do fluxo normativo (alto nível).
 3. **Token Replay** — execução do TBR com controles manuais, contendo **o modelo normativo no topo** e **o replay abaixo**, **empilhados verticalmente** (não lado a lado), para facilitar a inspeção em modelos grandes.
 4. **Gerador de Logs XES/CSV** — criação de logs sintéticos a partir de frequências de traços, com opção de download em XES ou CSV.
+5. **Alignments** — execução do algoritmo de alignments do PM4Py a partir de um log CSV, exibindo os resultados completos.
 
 """
 )

--- a/pages/4_Alignment.py
+++ b/pages/4_Alignment.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+"""Página de alignments baseada em PM4Py.
+
+Permite o upload de um log em CSV e executa o algoritmo de
+alignments sobre o modelo normativo N₃, exibindo os resultados
+completos retornados pela API do PM4Py.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+import io
+
+import pandas as pd
+import streamlit as st
+
+from pm4py.algo.conformance.alignments.petri_net import algorithm as alignments
+from pm4py.objects.conversion.log import converter as log_converter
+
+from replayviz.pm4py_model import build_net_N3
+
+
+st.set_page_config(page_title="Alignments — N₃", layout="wide")
+st.title("Alignments (N₃) — PM4Py")
+
+st.subheader("Seleção do Log (CSV)")
+uploaded = st.file_uploader("Carregue um CSV", type=["csv"])
+path_input = st.text_input("Ou caminho para um CSV existente", "")
+
+# Determina a origem do CSV e carrega em DataFrame
+df: Optional[pd.DataFrame] = None
+try:
+    if uploaded is not None:
+        df = pd.read_csv(io.BytesIO(uploaded.getvalue()))
+    elif path_input.strip():
+        df = pd.read_csv(path_input.strip())
+    else:
+        st.info("Carregue um CSV para prosseguir.")
+        st.stop()
+except Exception as e:  # pragma: no cover - mensagem ao usuário
+    st.error(f"Falha ao ler o CSV: {e}")
+    st.stop()
+
+# Converte para EventLog
+try:
+    if "time:timestamp" in df.columns:
+        df["time:timestamp"] = pd.to_datetime(df["time:timestamp"])
+    log = log_converter.apply(df)
+    st.success(f"Log carregado (traços: {len(log)})")
+except Exception as e:  # pragma: no cover - mensagem ao usuário
+    st.error(f"Falha ao converter o log: {e}")
+    st.stop()
+
+# Modelo normativo N3
+net, im, fm, _, _ = build_net_N3()
+
+# Execução dos alignments
+align_result = alignments.apply_log(log, net, im, fm)
+
+rows: List[Dict[str, Any]] = []
+for i, res in enumerate(align_result, start=1):
+    row: Dict[str, Any] = {"trace": i}
+    # inclui todos os campos retornados pela API
+    row.update(res)
+    rows.append(row)
+
+st.subheader("Resultados dos Alignments")
+st.dataframe(pd.DataFrame(rows), use_container_width=True)


### PR DESCRIPTION
## Summary
- Add a new Streamlit page to run PM4Py alignments on a CSV log
- Update the main app description to include the new Alignments page

## Testing
- `python -m py_compile app.py pages/4_Alignment.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0bbfa668c83319428eee4a856d948